### PR TITLE
jest.requireActual('jest-preset-angular');

### DIFF
--- a/addons/storyshots/storyshots-core/src/frameworks/angular/loader.ts
+++ b/addons/storyshots/storyshots-core/src/frameworks/angular/loader.ts
@@ -17,7 +17,7 @@ function setupAngularJestPreset() {
   // is running inside jest -  one of the things that `jest-preset-angular/setupJest` does is
   // extending the `window.Reflect` with all the needed metadata functions, that are required
   // for emission of the TS decorations like 'design:paramtypes'
-  jest.requireActual('jest-preset-angular/setupJest');
+  jest.requireActual('jest-preset-angular');
 }
 
 function test(options: StoryshotsOptions): boolean {


### PR DESCRIPTION
Issue:
cannot find module jest-preset-angular build setupjest

## What I did
Changed path

## How to test
'jest-preset-angular/build/setupJest' replace to 'jest-preset-angular' replace for 

- Is this testable with Jest or Chromatic screenshots?
- Does this need a new example in the kitchen sink apps?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next` branch unless they are specific to current release. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
